### PR TITLE
Make Travis CI badge point at maintainer's account

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ trees
 .. image:: https://badge.fury.io/py/trees.png
     :target: http://badge.fury.io/py/trees
 
-.. image:: https://travis-ci.org/adelq/trees.svg
-    :target: https://travis-ci.org/adelq/trees
+.. image:: https://travis-ci.org/Ceasar/trees.svg
+    :target: https://travis-ci.org/Ceasar/trees
 
 Collection of various tree data structures.
 


### PR DESCRIPTION
Presently, the badge point's at adelq's account, who contributed the
badge. But since future contributions will likely be added to my repo,
the badge should point to point to my Travis CI account.